### PR TITLE
Exlude AppCode project files not to sync in git (.gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ DerivedData/
 *.perspectivev3
 !default.perspectivev3
 
+## AppCode project setting
+.idea/
+
 ## Obj-C/Swift specific
 *.hmap
 


### PR DESCRIPTION
AppCode IDE stores its project settings in the .idea directory.
This file does not need to be synced to git, is better to be stored only locally.
Developers using AppCode always see .idea when they try to commit as a new file; it is annoying.
It would be better to be excluded by using .gitignore.